### PR TITLE
[Design] Design Update M-006,M-007

### DIFF
--- a/src/app/seller/order/page.tsx
+++ b/src/app/seller/order/page.tsx
@@ -80,7 +80,7 @@ export default function NoShowOrderListPage() {
       location: 'center' as 'center',
       render: (res: OrderItemList) => (
         <span
-          className={`px-3 py-1 rounded-[20px] caption5 ${
+          className={`px-3 py-1 rounded-[20px] caption5 h-[26px] ${
             res.status === 'PENDING'
               ? 'bg-status-pending text-status-pending-foreground'
               : 'bg-status-completed text-status-completed-foreground'

--- a/src/components/features/dashboard/ContentPagenation.tsx
+++ b/src/components/features/dashboard/ContentPagenation.tsx
@@ -20,6 +20,7 @@ export default function Pagination({ totalPages, currentPage, onPageChange, clas
         variant='link'
         size='page'
         onClick={() => onPageChange(Math.max(0, validPage - 1))}
+        className='disabled:text-foreground-disable disabled:opacity-100'
         disabled={validPage === 0}
         >
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -37,6 +38,7 @@ export default function Pagination({ totalPages, currentPage, onPageChange, clas
         variant='link'
         size='page'
         onClick={() => onPageChange(Math.min(validTotalPages - 1, validPage + 1))}
+        className='disabled:text-foreground-disable disabled:opacity-100'
         disabled={validPage === validTotalPages - 1}
         >
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/features/order/NoShowOrderPanel.tsx
+++ b/src/components/features/order/NoShowOrderPanel.tsx
@@ -48,10 +48,10 @@ export default function NoShowOrderPanel({ mode, orderData, onStatusUpdate }: No
         <div className='flex flex-col gap-16'>
           {orderData?.items &&
             orderData.items.map((item) => (
-              <div key={item.orderItemId} className='grid grid-cols-4 gap-12  w-full'>
+              <div key={item.orderItemId} className='grid grid-cols-4 gap-10 w-full'>
                 <Label className='title1 col-span-2  text-label-semilight'>{item.menuName}</Label>
-                <Label className='text-right title1 flex-none'>{item.quantity}</Label>
-                <Label className='text-right title1 flex-none whitespace-nowrap'>{Number(item.unitPrice).toLocaleString()}원</Label>
+                <Label className='text-right body3 flex-none text-foreground-normal'>{item.quantity}</Label>
+                <Label className='text-right body3 flex-none whitespace-nowrap text-foreground-normal'>{Number(item.unitPrice).toLocaleString()}원</Label>
               </div>
             ))}
         </div>
@@ -64,11 +64,11 @@ export default function NoShowOrderPanel({ mode, orderData, onStatusUpdate }: No
         <div className='flex flex-col gap-16'>
           <div className='flex flex-row justify-between items-center'>
             <Label className='title1 text-label-semilight'>기존 판매금액</Label>
-            <Label className='body3 text-label'>{orderData?.totalPrice.toLocaleString()}원</Label>
+            <Label className='body3 text-label text-foreground-normal'>{orderData?.totalPrice.toLocaleString()}원</Label>
           </div>
           <div className='flex flex-row justify-between items-center'>
             <Label className='title1 text-label-semilight'>할인율</Label>
-            <Label className='body3 text-label'>{orderData?.items[0].discountPercent}%</Label>
+            <Label className='body3 text-label text-foreground-normal'>{orderData?.items[0].discountPercent}%</Label>
           </div>
           <div className='flex flex-row justify-between items-center'>
             <Label className='body3 text-foreground-normal'>최종 결제금액</Label>
@@ -92,7 +92,7 @@ export default function NoShowOrderPanel({ mode, orderData, onStatusUpdate }: No
           {parsedPaymentInfo.map((info) => (
             <div key={info.label} className='flex flex-row justify-between items-center gap-8'>
               <Label className='title1 text-label-semilight whitespace-nowrap flex-shrink-0'>{info.label}</Label>
-              <Label className='body3 text-label text-right flex-1'>{info.value}</Label>
+              <Label className='body3 text-label text-right flex-1 text-foreground-normal'>{info.value}</Label>
             </div>
           ))}
         </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function Footer() {
   return (
-    <footer className={`w-full border-t border-border-normal max-[400px]:bg-white bg-background-normal-foreground`}>
+    <footer className={`w-full border-t border-border-footer max-[400px]:bg-white bg-background-normal-foreground`}>
       {/* ✅ 전체는 중앙 정렬 */}
       <div className='w-full pt-40 pb-20'>
         {/* ✅ 내부 컨테이너 */}
@@ -24,8 +24,8 @@ export default function Footer() {
 
             {/* 오른쪽 */}
             <div className='flex flex-row text-right items-center gap-[10px]'>
-              <span className='text-foreground-normal text-base font-medium min-[400px]:body1'>고객센터</span>
-              <span className='text-primary text-xl font-bold min-[400px]:caption8'>1500-0000</span>
+              <span className='text-foreground-normal caption6 max-[400px]:caption4'>고객센터</span>
+              <span className='text-primary text-xl font-bold max-[400px]:caption8'>1500-0000</span>
             </div>
           </div>
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,6 +32,7 @@ const config = {
           tertiary: '#a3a3a3',
           quaternary: '#4c4c4c',
           'primary-emphasis': '#5929ba',
+          footer: '#d3d3d3',
         },
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
@@ -58,7 +59,7 @@ const config = {
           'normal-subtle': '#A3A3A3'
         },
         primary: {
-          DEFAULT: '#8949fe',
+          DEFAULT: '#8749fe',
           foreground: '#ffffff',
         },
         secondary: {
@@ -186,6 +187,9 @@ const config = {
         40: 'var(--padding-40)',
       },
       gap: {
+        10: '10px',
+        12: '12px',
+        14: '14px',
         16: '16px',
         20: '20px',
         24: '24px',


### PR DESCRIPTION
- [x] 푸터 Divider 색상 수정
- [x] 테이블의 배찌 높이 26px고정
- [x] 푸터 고객센터 글자 caption6 수정
- [x] tailwindcss primary 색상 8749FE 수정
- [x] outline 속성의 버튼 글자 색상 text-foreground-normal
- [x] 오른쪽 판넬의 value text-foreground-normal 로 색상 조절
- [x] 주문메뉴 gap-10 수정
- [x] 주문 메뉴 금액, 수량 부분 Spec 수정
- [x] 페이지네이션 화살표 색상수정