### PR TITLE
[refactore] sort table

### DIFF
--- a/src/app/seller/no-show/page.tsx
+++ b/src/app/seller/no-show/page.tsx
@@ -25,9 +25,12 @@ export default function NoShowMenuPage() {
     detailError,
     setSelectNoshowItem,
     onSelected,
-    handleSort,
     handlePageChange,
     setActiveEdit,
+    // sort
+    handleSort,
+    sortState,
+    sortedReservations: sortedNoShowList,
   } = useNoShowManage();
 
   // const handleSelectStatus = (item: string) => {
@@ -57,8 +60,9 @@ export default function NoShowMenuPage() {
   const columns = [
     {
       key: 'time',
+      sortKey: 'visitTime', // 실제 데이터 필드명
       header: '시간',
-      // sortable: true,
+      sortable: true, // 페이지 하나당 정렬 > 정렬 훅 추가 필요
       render: (res: { visitTime: string | number | Date }) =>
         new Date(res.visitTime).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false }),
     },
@@ -108,7 +112,7 @@ export default function NoShowMenuPage() {
         title='노쇼 메뉴 상태를 관리해요'
         showFilters={false}
         columns={columns}
-        data={noShowList || []}
+        data={sortedNoShowList || []}
         expiredData={[]}
         // onSelected={onSelected} // 행 클릭 비활성화
         isUpdating={activeEdit}
@@ -116,6 +120,8 @@ export default function NoShowMenuPage() {
         page={Number(cursor)}
         onPageChange={handlePageChange}
         emptyMessage={'노쇼가 없습니다.'} // TODO: 멘트 추천받기
+        sortState={sortState}
+        onSort={handleSort}
       />
     );
   }
@@ -130,7 +136,7 @@ export default function NoShowMenuPage() {
             title='노쇼 메뉴 상태를 관리해요'
             showFilters={false}
             columns={columns}
-            data={noShowList || []}
+            data={sortedNoShowList || []}
             expiredData={[]}
             // onSelected={onSelected} // 행 클릭 비활성화
             isUpdating={activeEdit}
@@ -138,6 +144,8 @@ export default function NoShowMenuPage() {
             page={Number(cursor)}
             onPageChange={handlePageChange}
             emptyMessage='오늘 노쇼가 없습니다!' // TODO: 멘트 추천받기
+            onSort={handleSort}
+            sortState={sortState}
           />
         }
         panelType='noshow-edit'

--- a/src/app/seller/order/page.tsx
+++ b/src/app/seller/order/page.tsx
@@ -26,9 +26,11 @@ export default function NoShowOrderListPage() {
     error,
     onSelected,
     handlePageChange,
-    handleFilterChange, // 현재는 구현 필요 없음
-    handleSort, // 현재는 구현 필요 없음
+    handleFilterChange, // 구현 진행중 (백엔드 필터링 필요)
+    handleSort, // 정렬
     handleCompleteVisit,
+
+    sortState,
   } = useSellerOrderManage();
 
   /** 방문 완료 요청 - Dialog 띄우기 */
@@ -61,9 +63,11 @@ export default function NoShowOrderListPage() {
 
   // 테이블 컬럼 (UI용)
   const columns = [
-    { key: 'orderId', header: '주문번호' },
+    { key: 'orderId', header: '주문번호', sortable: true },
     {
       key: 'visitTime',
+      sortable: true,
+      sortKey: 'visitTime', // 실제 데이터 필드명
       header: '시간',
       render: (res: { visitTime: string | number | Date }) => formatTimeString(new Date(res.visitTime)),
     },
@@ -107,6 +111,8 @@ export default function NoShowOrderListPage() {
         emptyMessage='주문 내역이 비어있습니다.'
         activeTab={activeFilter}
         selectItemId={selectItemId}
+        onSort={handleSort}
+        sortState={sortState}
       />
     );
   }
@@ -130,6 +136,8 @@ export default function NoShowOrderListPage() {
             emptyMessage='주문 내역이 비어있습니다.'
             activeTab={activeFilter}
             selectItemId={selectItemId}
+            onSort={handleSort}
+            sortState={sortState}
           />
         }
         panelType={'noshow-order-view'}

--- a/src/app/seller/page.tsx
+++ b/src/app/seller/page.tsx
@@ -198,7 +198,7 @@ function SellerPageContent() {
             tabs={tabs}
             showFilters={true}
             columns={columns}
-            data={reservations}
+            data={sortedReservations}
             expiredData={expiredReservations}
             onSelected={onSelectReservation}
             onTabChange={handleFilterChange}
@@ -209,6 +209,8 @@ function SellerPageContent() {
             emptyMessage='오늘 예약이 비어있습니다.'
             activeTab={activeTab}
             selectItemId={selectItemId}
+            onSort={handleSort}
+            sortState={sortState}
           />
         }
         // selectItemStatus 말고 다른 방법?

--- a/src/components/features/reservation/ReservationDetailPanel.tsx
+++ b/src/components/features/reservation/ReservationDetailPanel.tsx
@@ -25,7 +25,7 @@ export default function ReservationDetailPanel({
   onDataUpdate,
 }: ReservationDetailPanel) {
   return (
-    <div className='px-20 flex flex-col justify-between min-h-[758px] pt-[36px]'>
+    <div className='px-20 flex flex-col justify-between min-h-[758px] pt-[36px] w-[360px]'>
       <div className='flex flex-col gap-24'>
         <Label className='title5'>예약 정보</Label>
         {/* 예약 정보 */}

--- a/src/hooks/useNoShowForm.ts
+++ b/src/hooks/useNoShowForm.ts
@@ -201,7 +201,7 @@ export function useNoShowMenuForm(defaultData?: NoShowMenu) {
         discountPercent: defaultData.discountPercent,
         visitTime: serverVisitTime.toISOString(), // ISO 문자열로 저장
       });
-      console.log('폼 데이터 리셋:', defaultData);
+      // console.log('폼 데이터 리셋:', defaultData);
     }
   }, [defaultData, reset]);
 
@@ -259,10 +259,10 @@ export function useNoShowMenuForm(defaultData?: NoShowMenu) {
   const handleConfirmSubmit = useCallback(() => {
     if (!pendingFormData) return;
 
-    console.log('✅ 수정 확정 데이터:', {
-      ...pendingFormData,
-      visitTime: calculatedVisitTime.toISOString(),
-    });
+    // console.log('✅ 수정 확정 데이터:', {
+    //   ...pendingFormData,
+    //   visitTime: calculatedVisitTime.toISOString(),
+    // });
     // TODO: 실제 API 호출 로직 추가(필요시)
     setIsSubmitDialogOpen(false);
     setPendingFormData(null);

--- a/src/hooks/useNoShowManage.ts
+++ b/src/hooks/useNoShowManage.ts
@@ -4,8 +4,10 @@ import { getNowDateHyphenString } from '@/lib/dateParse';
 import { useNoShowStore } from '@/store/useNoShowStore';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { SortState } from '@/types/boardData';
+import { sortData, handleSortToggle } from '@/lib/sortUtils';
 
 export const useNoShowManage = () => {
   const router = useRouter();
@@ -31,6 +33,9 @@ export const useNoShowManage = () => {
     }
   };
 
+  // 정렬 상태
+  const [sortState, setSortState] = useState<SortState>({ key: '', order: null });
+
   const {
     data: noShowLists,
     isLoading,
@@ -47,7 +52,7 @@ export const useNoShowManage = () => {
           // date: new Date(),
         },
       });
-      console.log('response: ', response.data);
+      // console.log('response: ', response.data);
       return response.data;
     },
     staleTime: 1000 * 60 * 1,
@@ -100,7 +105,7 @@ export const useNoShowManage = () => {
     if (detailData) {
       const detail = detailData.data || detailData;
       setSelectNoshowItem(detail);
-      console.log('상세 데이터:', detail);
+      // console.log('상세 데이터:', detail);
     }
   }, [detailData, setSelectNoshowItem]);
 
@@ -119,9 +124,16 @@ export const useNoShowManage = () => {
 
   // 정렬 핸들러
   const handleSort = (key: string) => {
-    // 정렬 선택 시, refetch 호출, 백엔드에서 정렬 처리
-    // INFO: 정렬 상태 관리 필요 시 추가 구현
+    // 정렬 선택 시 기존의 데이터에서 직접 정렬 수행
+    // desc, asc 구분 필요
+    // console.log('정렬 키 선택됨:', key);
+    handleSortToggle(key, setSortState);
   };
+
+  // 정렬된 노쇼 메뉴 데이터
+  const sortedNoShowList = useMemo(() => {
+    return sortData(noShowList, sortState);
+  }, [noShowList, sortState]);
 
   return {
     // 상태
@@ -144,7 +156,10 @@ export const useNoShowManage = () => {
     onSelected,
     handlePageChange,
     setActiveEdit, // 임시로 추가
+    
     // sort
+    sortState,
+    sortedReservations: sortedNoShowList,
     handleSort,
   };
 };

--- a/src/hooks/useReservationApi.ts
+++ b/src/hooks/useReservationApi.ts
@@ -56,7 +56,7 @@ export const useReservationApi = () => {
       return data;
     },
     onSuccess: (data) => {
-      console.log('✅ 노쇼 처리 성공:', data);
+      // console.log('✅ 노쇼 처리 성공:', data);
       showAlarm('노쇼 메뉴 처리가 완료되었습니다.', 'success', '성공', true);
       queryClient.invalidateQueries({ queryKey: ['reservations'] });
       // 네비게이션을 onSuccess에서 처리

--- a/src/hooks/useReservationManger.ts
+++ b/src/hooks/useReservationManger.ts
@@ -8,6 +8,7 @@ import { useReservationStore } from '@/store/useReservationStore';
 import { useReservationTimer } from './useReservationTimer';
 import { useReservationApi } from './useReservationApi';
 import { Reservation, SortState } from '@/types/boardData';
+import { sortData, handleSortToggle } from '@/lib/sortUtils';
 
 export const useReservationManager = ({ userId = null }: { userId?: string | null }) => {
   const router = useRouter();
@@ -105,58 +106,13 @@ export const useReservationManager = ({ userId = null }: { userId?: string | nul
 
   // ✅ 정렬 핸들러
   const handleSort = (key: string) => {
-    setSortState((prev) => {
-      if (prev.key !== key) {
-        return { key, order: 'asc' };
-      }
-
-      switch (prev.order) {
-        case null:
-          return { key, order: 'asc' };
-        case 'asc':
-          return { key, order: 'desc' };
-        case 'desc':
-          return { key, order: null };
-        default:
-          return { key, order: 'asc' };
-      }
-    });
+    // console.log('Sorting by key:', key);
+    handleSortToggle(key, setSortState);
   };
 
   // ✅ 정렬된 예약 데이터
   const sortedReservations = useMemo(() => {
-    if (!sortState.key || !sortState.order) {
-      return reservations;
-    }
-
-    return [...reservations].sort((a, b) => {
-      const key = sortState.key as keyof typeof a;
-      let aValue = a[key];
-      let bValue = b[key];
-
-      // 시간 정렬 특별 처리
-      if (key === 'time') {
-        const aTime = new Date(aValue as unknown as string).getTime();
-        const bTime = new Date(bValue as unknown as string).getTime();
-        return sortState.order === 'asc' ? aTime - bTime : bTime - aTime;
-      }
-
-      // 문자열 정렬
-      if (typeof aValue === 'string' && typeof bValue === 'string') {
-        const result = aValue.localeCompare(bValue);
-        return sortState.order === 'asc' ? result : -result;
-      }
-
-      // 숫자 정렬
-      if (typeof aValue === 'number' && typeof bValue === 'number') {
-        return sortState.order === 'asc' ? aValue - bValue : bValue - aValue;
-      }
-
-      // 기본 정렬
-      if (aValue < bValue) return sortState.order === 'asc' ? -1 : 1;
-      if (aValue > bValue) return sortState.order === 'asc' ? 1 : -1;
-      return 0;
-    });
+    return sortData(reservations, sortState);
   }, [reservations, sortState]);
 
   return {

--- a/src/hooks/useSellerOrderManage.ts
+++ b/src/hooks/useSellerOrderManage.ts
@@ -1,12 +1,13 @@
 import { getNowDateHyphenString } from '@/lib/dateParse';
 import { useSellerOrderStore } from '@/store/useSellerOrder';
 import { useAlarmStore } from '@/store/useAlarmStore';
-import { OrderDetail } from '@/types/boardData';
+import { OrderDetail, SortState } from '@/types/boardData';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import axios from 'axios';
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { set } from 'zod';
+import { sortData, handleSortToggle } from '@/lib/sortUtils';
 
 export const useSellerOrderManage = () => {
   const router = useRouter();
@@ -24,6 +25,7 @@ export const useSellerOrderManage = () => {
   } = useSellerOrderStore();
   const { showAlarm } = useAlarmStore();
   const queryClient = useQueryClient();
+  const [sortState, setSortState] = useState<SortState>({ key: '', order: null });
 
   // 에러 처리 핸들러
   const handleQueryError = (error: any) => {
@@ -114,9 +116,9 @@ export const useSellerOrderManage = () => {
     // 구현 필요 시 추가
   };
 
-  // 정렬 핸들러 > 당장 구현하지 않음
+  // 정렬 핸들러 
   const handleSort = (key: string) => {
-    // 구현 필요 시 추가
+    handleSortToggle(key, setSortState);
   };
 
   // 선택한 주문내역 아이템 세팅
@@ -157,8 +159,12 @@ export const useSellerOrderManage = () => {
     completeVisitMutation.mutate(orderId);
   };
 
+  const sortOrders = useMemo(() => {
+    return sortData(orders, sortState);
+  },[orders, sortState]);
+
   return {
-    orders,
+    orders: sortOrders,
     selectItemId,
     cursor: pagination?.page || 0,
     totalPages: pagination?.totalPages || 0,
@@ -173,5 +179,8 @@ export const useSellerOrderManage = () => {
     handleFilterChange, // 현재는 구현 필요 없음
     handleSort, // 현재는 구현 필요 없음
     handleCompleteVisit, // 방문 완료 핸들러
+
+    //sort
+    sortState,
   };
 };

--- a/src/lib/sortUtils.ts
+++ b/src/lib/sortUtils.ts
@@ -1,0 +1,62 @@
+import { SortState } from '@/types/boardData';
+import { Dispatch, SetStateAction } from 'react';
+
+/**
+ * 정렬 상태를 토글하는 핸들러 함수
+ * @param key 정렬할 컬럼 키
+ * @param setSortState 정렬 상태를 업데이트하는 setState 함수
+ */
+export function handleSortToggle(key: string, setSortState: Dispatch<SetStateAction<SortState>>): void {
+  setSortState((prevState) => {
+    let newOrder: 'asc' | 'desc' | null = 'asc';
+    if (prevState.key === key) {
+      if (prevState.order === 'asc') {
+        newOrder = 'desc';
+      } else if (prevState.order === 'desc') {
+        newOrder = null;
+      }
+    }
+    return { key, order: newOrder };
+  });
+}
+
+/**
+ * 배열 데이터를 정렬하는 범용 유틸리티 함수
+ * @param data 정렬할 데이터 배열
+ * @param sortState 정렬 상태 (key, order)
+ * @returns 정렬된 데이터 배열
+ */
+export function sortData<T extends Record<string, any>>(data: T[], sortState: SortState): T[] {
+  if (!sortState.key || !sortState.order) {
+    return data;
+  }
+
+  return [...data].sort((a, b) => {
+    const key = sortState.key as keyof T;
+    const aValue = a[key];
+    const bValue = b[key];
+
+    // 시간 정렬 특별 처리 (time, visitTime 모두 지원)
+    if (key === 'time' || key === 'visitTime') {
+      const aTime = new Date(aValue as unknown as string).getTime();
+      const bTime = new Date(bValue as unknown as string).getTime();
+      return sortState.order === 'asc' ? aTime - bTime : bTime - aTime;
+    }
+
+    // 문자열 정렬
+    if (typeof aValue === 'string' && typeof bValue === 'string') {
+      const result = aValue.localeCompare(bValue);
+      return sortState.order === 'asc' ? result : -result;
+    }
+
+    // 숫자 정렬
+    if (typeof aValue === 'number' && typeof bValue === 'number') {
+      return sortState.order === 'asc' ? aValue - bValue : bValue - aValue;
+    }
+
+    // 기본 정렬
+    if (aValue < bValue) return sortState.order === 'asc' ? -1 : 1;
+    if (aValue > bValue) return sortState.order === 'asc' ? 1 : -1;
+    return 0;
+  });
+}


### PR DESCRIPTION
- [x] 사장님 페이지의 테이블 sort 적용
    - 따로 api 호출하지않고 진행(한 페이지 내의 데이터만 핸들링 하는 방향으로 논의함)
- [x] sorting 함수 util로 분리
    - 총 90줄의 중복코드 제거
    - [`sortUtils.ts`](src/lib/sortUtils.ts) 생성
- [x] console.log 제거